### PR TITLE
Fix duplicate initializer invocation in certain conditions

### DIFF
--- a/dist/index.es6.js
+++ b/dist/index.es6.js
@@ -476,12 +476,21 @@ class ViewController extends React.Component {
         
         if (!me.$initialized) {
             if (typeof initialize === 'function') {
+                const initializeWrapper = me.$initializeWrapper ||
+                    (me.$initializeWrapper = (...args) => {
+                        // Initializer function is possibly making changes to the
+                        // parent ViewModel state, which might cause extra rendering
+                        // of this ViewController. To avoid extraneous invocations
+                        // of the initializer function, clear the flags before invoking it.
+                        me.$initialized = true;
+                        delete me.$initializeWrapper;
+                        
+                        initialize(...args);
+                    });
+                
                 // We have to defer executing the function because setting state
                 // is prohibited during rendering cycle.
-                me.defer((...args) => {
-                    initialize(...args);
-                    me.$initialized = true;
-                }, vc);
+                me.defer(initializeWrapper, vc, true);
             }
             else {
                 me.$initialized = true;
@@ -502,7 +511,7 @@ class ViewController extends React.Component {
         const { id, $viewModel, handlers, children } = me.props;
         
         const innerVC = ({ vm }) => 
-            React.createElement(ViewControllerContext.Consumer, {__self: this, __source: {fileName: _jsxFileName, lineNumber: 114}}
+            React.createElement(ViewControllerContext.Consumer, {__self: this, __source: {fileName: _jsxFileName, lineNumber: 123}}
                 ,  parent => {
                     const vc = accessorizeViewController(vm, {
                         id: id || me.id,
@@ -526,7 +535,7 @@ class ViewController extends React.Component {
                     me.runRenderHandlers(vc, me.props);
                     
                     return (
-                        React.createElement(ViewControllerContext.Provider, { value: vc, __self: this, __source: {fileName: _jsxFileName, lineNumber: 138}}
+                        React.createElement(ViewControllerContext.Provider, { value: vc, __self: this, __source: {fileName: _jsxFileName, lineNumber: 147}}
                             ,  children 
                         )
                     );
@@ -535,7 +544,7 @@ class ViewController extends React.Component {
     
         return $viewModel
             ? innerVC({ vm: $viewModel })
-            : React.createElement(ViewModelContext.Consumer, {__self: this, __source: {fileName: _jsxFileName, lineNumber: 147}}
+            : React.createElement(ViewModelContext.Consumer, {__self: this, __source: {fileName: _jsxFileName, lineNumber: 156}}
                 ,  innerVC 
               );
     }

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -898,12 +898,19 @@ function (_React$Component) {
 
       if (!me.$initialized) {
         if (typeof initialize === 'function') {
-          // We have to defer executing the function because setting state
-          // is prohibited during rendering cycle.
-          me.defer(function () {
-            initialize.apply(void 0, arguments);
+          var initializeWrapper = me.$initializeWrapper || (me.$initializeWrapper = function () {
+            // Initializer function is possibly making changes to the
+            // parent ViewModel state, which might cause extra rendering
+            // of this ViewController. To avoid extraneous invocations
+            // of the initializer function, clear the flags before invoking it.
             me.$initialized = true;
-          }, vc);
+            delete me.$initializeWrapper;
+            initialize.apply(void 0, arguments);
+          }); // We have to defer executing the function because setting state
+          // is prohibited during rendering cycle.
+
+
+          me.defer(initializeWrapper, vc, true);
         } else {
           me.$initialized = true;
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -905,12 +905,19 @@ function (_React$Component) {
 
       if (!me.$initialized) {
         if (typeof initialize === 'function') {
-          // We have to defer executing the function because setting state
-          // is prohibited during rendering cycle.
-          me.defer(function () {
-            initialize.apply(void 0, arguments);
+          var initializeWrapper = me.$initializeWrapper || (me.$initializeWrapper = function () {
+            // Initializer function is possibly making changes to the
+            // parent ViewModel state, which might cause extra rendering
+            // of this ViewController. To avoid extraneous invocations
+            // of the initializer function, clear the flags before invoking it.
             me.$initialized = true;
-          }, vc);
+            delete me.$initializeWrapper;
+            initialize.apply(void 0, arguments);
+          }); // We have to defer executing the function because setting state
+          // is prohibited during rendering cycle.
+
+
+          me.defer(initializeWrapper, vc, true);
         } else {
           me.$initialized = true;
         }

--- a/test/ViewController.test.js
+++ b/test/ViewController.test.js
@@ -54,6 +54,21 @@ describe("ViewController", () => {
             
             expect(counter).toBe(1);
         });
+        
+        test("it should run initialize only once when ViewController is re-rendered before running initialize", async () => {
+            let counter = 0;
+            
+            const tree = mount(
+                <ViewController initialize={() => counter++} />
+            );
+            
+            tree.mount();
+            tree.mount();
+            
+            await sleep();
+            
+            expect(counter).toBe(1);
+        });
     });
     
     describe("invalidate", () => {


### PR DESCRIPTION
If ViewController is re-rendered before initialize function is invoked,
previous scheduled invocations were not correctly cancelled.