### PR TITLE
Change license property in package.json to be a valid SPDX string

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,5 @@
   },
   "repository": "git@github.com:riptano/statium.git",
   "author": "Alex Tokarev",
-  "license": "Apache 2.0"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
Fix yarn warning.