### PR TITLE
Fix #11: Random binding failures when Statium is bundled more than once

### DIFF
--- a/dist/index.es6.js
+++ b/dist/index.es6.js
@@ -44,8 +44,49 @@ const rootViewController = {
     $dispatch: defaultDispatch,
 };
 
-const ViewModelContext = React.createContext({ vm: rootViewModel });
-const ViewControllerContext = React.createContext(rootViewController);
+// One often encountered problem is package being included more than once
+// in the application bundle, due to bundler misconfiguration or some other
+// reason. If that happens, each copy of the Statium package will have its own
+// pair of private ViewModel and ViewController contexts; this will lead to
+// _seriously_ hairy bugs that are really hard to track.
+// To avoid this issue, we simply cache context objects in the window.
+const ViewModelContext = (() => {
+    let context;
+    
+    try {
+        if (window.__$StatiumViewModelContext) {
+            context = window.__$StatiumViewModelContext;
+        }
+        else {
+            context = React.createContext({ vm: rootViewModel });
+            window.__$StatiumViewModelContext = context;
+        }
+    }
+    catch (e) {
+        context = React.createContext({ vm: rootViewModel });
+    }
+    
+    return context;
+})();
+
+const ViewControllerContext = (() => {
+    let context;
+    
+    try {
+        if (window.__$StatiumViewControllerContext) {
+            context = window.__$StatiumViewControllerContext;
+        }
+        else {
+            context = window.__$StatiumViewControllerContext =
+                React.createContext(rootViewController);
+        }
+    }
+    catch (e) {
+        context = React.createContext(rootViewController);
+    }
+    
+    return context;
+})();
 
 let idCounter = 0;
 

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -294,11 +294,48 @@ var rootViewController = {
   $get: rootViewModel.$retrieve,
   $set: rootViewModel.$set,
   $dispatch: defaultDispatch
-};
-var ViewModelContext = React.createContext({
-  vm: rootViewModel
-});
-var ViewControllerContext = React.createContext(rootViewController);
+}; // One often encountered problem is package being included more than once
+// in the application bundle, due to bundler misconfiguration or some other
+// reason. If that happens, each copy of the Statium package will have its own
+// pair of private ViewModel and ViewController contexts; this will lead to
+// _seriously_ hairy bugs that are really hard to track.
+// To avoid this issue, we simply cache context objects in the window.
+
+var ViewModelContext = function () {
+  var context;
+
+  try {
+    if (window.__$StatiumViewModelContext) {
+      context = window.__$StatiumViewModelContext;
+    } else {
+      context = React.createContext({
+        vm: rootViewModel
+      });
+      window.__$StatiumViewModelContext = context;
+    }
+  } catch (e) {
+    context = React.createContext({
+      vm: rootViewModel
+    });
+  }
+
+  return context;
+}();
+var ViewControllerContext = function () {
+  var context;
+
+  try {
+    if (window.__$StatiumViewControllerContext) {
+      context = window.__$StatiumViewControllerContext;
+    } else {
+      context = window.__$StatiumViewControllerContext = React.createContext(rootViewController);
+    }
+  } catch (e) {
+    context = React.createContext(rootViewController);
+  }
+
+  return context;
+}();
 
 var idCounter = 0;
 var getId = function getId(prefix) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -301,11 +301,48 @@ var rootViewController = {
   $get: rootViewModel.$retrieve,
   $set: rootViewModel.$set,
   $dispatch: defaultDispatch
-};
-var ViewModelContext = React__default.createContext({
-  vm: rootViewModel
-});
-var ViewControllerContext = React__default.createContext(rootViewController);
+}; // One often encountered problem is package being included more than once
+// in the application bundle, due to bundler misconfiguration or some other
+// reason. If that happens, each copy of the Statium package will have its own
+// pair of private ViewModel and ViewController contexts; this will lead to
+// _seriously_ hairy bugs that are really hard to track.
+// To avoid this issue, we simply cache context objects in the window.
+
+var ViewModelContext = function () {
+  var context;
+
+  try {
+    if (window.__$StatiumViewModelContext) {
+      context = window.__$StatiumViewModelContext;
+    } else {
+      context = React__default.createContext({
+        vm: rootViewModel
+      });
+      window.__$StatiumViewModelContext = context;
+    }
+  } catch (e) {
+    context = React__default.createContext({
+      vm: rootViewModel
+    });
+  }
+
+  return context;
+}();
+var ViewControllerContext = function () {
+  var context;
+
+  try {
+    if (window.__$StatiumViewControllerContext) {
+      context = window.__$StatiumViewControllerContext;
+    } else {
+      context = window.__$StatiumViewControllerContext = React__default.createContext(rootViewController);
+    }
+  } catch (e) {
+    context = React__default.createContext(rootViewController);
+  }
+
+  return context;
+}();
 
 var idCounter = 0;
 var getId = function getId(prefix) {

--- a/src/context.js
+++ b/src/context.js
@@ -38,5 +38,46 @@ export const rootViewController = {
     $dispatch: defaultDispatch,
 };
 
-export const ViewModelContext = React.createContext({ vm: rootViewModel });
-export const ViewControllerContext = React.createContext(rootViewController);
+// One often encountered problem is package being included more than once
+// in the application bundle, due to bundler misconfiguration or some other
+// reason. If that happens, each copy of the Statium package will have its own
+// pair of private ViewModel and ViewController contexts; this will lead to
+// _seriously_ hairy bugs that are really hard to track.
+// To avoid this issue, we simply cache context objects in the window.
+export const ViewModelContext = (() => {
+    let context;
+    
+    try {
+        if (window.__$StatiumViewModelContext) {
+            context = window.__$StatiumViewModelContext;
+        }
+        else {
+            context = React.createContext({ vm: rootViewModel });
+            window.__$StatiumViewModelContext = context;
+        }
+    }
+    catch (e) {
+        context = React.createContext({ vm: rootViewModel });
+    }
+    
+    return context;
+})();
+
+export const ViewControllerContext = (() => {
+    let context;
+    
+    try {
+        if (window.__$StatiumViewControllerContext) {
+            context = window.__$StatiumViewControllerContext;
+        }
+        else {
+            context = window.__$StatiumViewControllerContext =
+                React.createContext(rootViewController);
+        }
+    }
+    catch (e) {
+        context = React.createContext(rootViewController);
+    }
+    
+    return context;
+})();


### PR DESCRIPTION
No unit tests were harmed in this PR, simply because it's kinda hard to reproduce this issue intentionally. I still have no idea what Webpack glitch lead to this cropping up in one of my personal projects, but it did.

If I come up with an idea of how to repro it, I'll add a test later.
