### PR TITLE
Exceptions in asynchronous ViewController handlers are rethrown at render

### DIFF
--- a/src/ViewController.js
+++ b/src/ViewController.js
@@ -70,6 +70,8 @@ export class ViewController extends React.Component {
         this.timerMap = new Map();
         this.defer = this.defer.bind(this);
         this.runRenderHandlers = this.runRenderHandlers.bind(this);
+
+        this.state = { error: null };
     }
     
     componentWillUnmount() {
@@ -95,8 +97,10 @@ export class ViewController extends React.Component {
                     
                     resolve(result);
                 }
-                catch (e) {
-                    reject(e);
+                catch (error) {
+                    this.setState({ error }, () => {
+                        reject(error);
+                    });
                 }
             });
         });
@@ -143,6 +147,12 @@ export class ViewController extends React.Component {
     }
     
     render() {
+        const { error } = this.state;
+
+        if (error) {
+            throw error;
+        }
+
         const me = this;
         
         const { id, $viewModel, handlers, children } = me.props;

--- a/test/console.js
+++ b/test/console.js
@@ -1,0 +1,13 @@
+const cnsl = {
+    log: console.log,
+    warn: console.warn,
+    error: console.error,
+};
+
+export const bork = what => {
+    console[what] = () => {};
+};
+
+export const unbork = what => {
+    console[what] = cnsl[what];
+};


### PR DESCRIPTION
Ticket: https://github.com/riptano/statium/issues/14

Upon further reflection, I cannot come up with a definite use case for explicit exception handler; specifically, a case where rethrowing exception at render would not be enough.

Additional considerations:
* Async handlers with complex business logic are unlikely to use default exception handling, and most probably are going to utilize `try/catch` blocks with custom approach to exceptions
* Inheritance semantics are unclear for explicit exception handlers. If we provide `onError` prop to a parent ViewController, should descendant controllers inherit it, or should the handler apply only to the controller where it is specified? There are pros and cons either way.

Now that async exception handling is in place, adding another handling vector is going to be trivial if needed in the future.