### PR TITLE
Added basic typescript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-sucrase": "^2.1.0",
-    "sucrase": "^3.15.0"
+    "sucrase": "^3.15.0",
+    "typescript": "^4.0.2"
   },
   "files": [
     "dist"

--- a/src/Bind.d.ts
+++ b/src/Bind.d.ts
@@ -1,0 +1,5 @@
+export function Bind({ props, controller, children }: {
+    props: any;
+    controller: any;
+    children: any;
+}): any;

--- a/src/ViewController.d.ts
+++ b/src/ViewController.d.ts
@@ -1,0 +1,26 @@
+export function exceptionificate(fn: any, vm: any): (...args: any[]) => any;
+export function expose({ vm, $get, $set, $dispatch }: {
+    vm: any;
+    $get: any;
+    $set: any;
+    $dispatch: any;
+}): {
+    $get: (...args: any[]) => any;
+    $set: (...args: any[]) => any;
+    $dispatch: (...args: any[]) => any;
+};
+export function invalidSet(): never;
+export function invalidDispatch(): never;
+export class ViewController {
+    constructor(props: any);
+    id: any;
+    timerMap: Map<any, any>;
+    defer(fn: any, vc: any, wantPromise: any, ...args: any[]): Promise<any>;
+    runRenderHandlers(vc: any, props: any): void;
+    state: {
+        error: any;
+    };
+    componentWillUnmount(): void;
+    execute(fn: any, vc: any, args: any, resolve: any, reject: any): Promise<any>;
+    render(): any;
+}

--- a/src/ViewModel.d.ts
+++ b/src/ViewModel.d.ts
@@ -1,0 +1,10 @@
+export function applyViewModelState(currentState: any, values: any): any;
+export function ViewModelWrapper(props: any): any;
+export namespace ViewModelWrapper {
+    namespace defaultProps {
+        const data: {};
+        const initialState: {};
+        const formulas: {};
+        const applyState: any;
+    }
+}

--- a/src/accessors.d.ts
+++ b/src/accessors.d.ts
@@ -1,0 +1,9 @@
+export const accessorType: unique symbol;
+export function multiGet(vm: any, keys: any): any;
+export function multiSet({ vm, forceKey, single }: {
+    vm: any;
+    forceKey: any;
+    single: any;
+}, key: any, value: any): any;
+export function accessorizeViewModel(vm: any): any;
+export function validateInitialState(state: any, vm: any): boolean;

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -1,0 +1,13 @@
+export function normalizeBindings(bindings: {}, variadic: any): ({
+    propName: any;
+    key: any;
+    formula: any;
+} | {
+    formula?: any;
+    setterName?: any;
+    propName: any;
+    key: any;
+    publish: any;
+})[];
+export function mapProps(vm: any, bindings: any): any;
+export function mapPropsToArray(vm: any, bindings: any): any;

--- a/src/context.d.ts
+++ b/src/context.d.ts
@@ -1,0 +1,26 @@
+export class ViewModelUnmountedError extends Error {
+    constructor(...args: any[]);
+    isViewModelUnmounted: boolean;
+}
+export namespace rootViewModel {
+    export const formulas: {};
+    export const data: {};
+    export const state: {};
+    export const store: {};
+    export { defaultGet as $get };
+    export { defaultSet as $set };
+    export function $resolveValue(key: any): void;
+    export { defaultDispatch as $dispatch };
+}
+export namespace rootViewController {
+    export { rootViewModel as vm };
+    export const $get: any;
+    import $set = rootViewModel.$set;
+    export { $set };
+    export { defaultDispatch as $dispatch };
+}
+export const Context: any;
+declare function defaultGet(key: any): void;
+declare function defaultSet(key: any, value: any): void;
+declare function defaultDispatch(event: any, ...payload: any[]): void;
+export {};

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,7 @@
+export { ViewModelUnmountedError } from "./context.js";
+export { ViewModelWrapper as default } from "./ViewModel.js";
+export { ViewController } from "./ViewController.js";
+export { Bind } from "./Bind.js";
+export { withBindings } from "./withBindings.js";
+export { useBindings } from "./useBindings.js";
+export { useController } from "./useController.js";

--- a/src/useBindings.d.ts
+++ b/src/useBindings.d.ts
@@ -1,0 +1,1 @@
+export function useBindings(..._bindings: any[]): any;

--- a/src/useController.d.ts
+++ b/src/useController.d.ts
@@ -1,0 +1,5 @@
+export function useController(): {
+    $get: (...args: any[]) => any;
+    $set: (...args: any[]) => any;
+    $dispatch: (...args: any[]) => any;
+};

--- a/src/util.d.ts
+++ b/src/util.d.ts
@@ -1,0 +1,10 @@
+export function ucfirst(str: any): string;
+export function getId(prefix: any): string;
+export function chain(proto: any, ...sources: any[]): any;
+export function setterNameForKey(key: any): string;
+export function getKeys(object: any): any[];
+export function getKeyPrefix(key: any): string | symbol;
+export function validKey(key: any): boolean;
+export function findOwner(object: any, entityName: any, key: any): any[];
+export function normalizeProtectedKeys(keys: any): any;
+export function defer(fn: any, timeout?: number): NodeJS.Timeout;

--- a/src/withBindings.d.ts
+++ b/src/withBindings.d.ts
@@ -1,0 +1,4 @@
+export function withBindings(...boundProps: any[]): (Component: any) => {
+    (componentProps: any): any;
+    displayName: string;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "lib": ["ES6"]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5452,6 +5452,11 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"


### PR DESCRIPTION
This PR introduces basic TypeScript support into the project. Only the type definition files were created based on the current codebase with no code change on plain JavaScript files.

This is an initial step. In the future, the definitions should be improved, e.g. replacing `any` with proper/more strict type where applicable.